### PR TITLE
Task priorities

### DIFF
--- a/batch-codegen/src/lib.rs
+++ b/batch-codegen/src/lib.rs
@@ -32,13 +32,16 @@ use syn::{DeriveInput, Ident, Lit, Meta};
 /// * `task_timeout`: Number of seconds available for the task to execute. If the time limit is
 ///   exceeded, the task's process is killed and the task is marked as failed.
 ///   e.g: `#[task_timeout = "120"]`
-///   **default value**: 900 (15 minutes)
+///   **default value**: `900` (15 minutes)
 /// * `task_retries`: Number of times the task should be retried in case of error.
 ///   e.g: `#[task_retries = "5"]`
-///   **default value**: 2
+///   **default value**: `2`
+/// * `task_priority`: The priority associated to the task
+///   e.g: `#[task_priority = "critical"]`
+///   **default value**: `"normal"`
 #[proc_macro_derive(Task,
                     attributes(task_name, task_exchange, task_routing_key, task_timeout,
-                               task_retries))]
+                               task_retries, task_priority))]
 pub fn task_derive(input: TokenStream) -> TokenStream {
     let input: DeriveInput = syn::parse(input).unwrap();
     let task_name = get_derive_name_attr(&input);
@@ -46,6 +49,7 @@ pub fn task_derive(input: TokenStream) -> TokenStream {
     let task_routing_key = get_derive_routing_key_attr(&input);
     let task_timeout = get_derive_timeout_attr(&input);
     let task_retries = get_derive_retries_attr(&input);
+    let task_priority = get_derive_priority_attr(&input);
     let name = &input.ident;
 
     let expanded = quote! {
@@ -69,6 +73,10 @@ pub fn task_derive(input: TokenStream) -> TokenStream {
 
             fn retries() -> u32 {
                 #task_retries
+            }
+
+            fn priority() -> ::batch::Priority {
+                #task_priority
             }
         }
     };
@@ -120,6 +128,23 @@ fn get_derive_retries_attr(input: &DeriveInput) -> Tokens {
         .expect("Couldn't parse retries as an unsigned integer");
     quote! {
         #retries
+    }
+}
+
+fn get_derive_priority_attr(input: &DeriveInput) -> Tokens {
+    let attr = {
+        let raw = get_str_attr_by_name(&input.attrs, "task_priority");
+        raw.unwrap_or_else(|| "normal".to_string())
+    };
+    match attr.to_lowercase().as_ref() {
+        "trivial" => quote! { ::batch::Priority::Trivial },
+        "low" => quote! { ::batch::Priority::Low },
+        "normal" => quote! { ::batch::Priority::Normal },
+        "high" => quote! { ::batch::Priority::High },
+        "critical" => quote! { ::batch::Priority::Critical },
+        _ => {
+            panic!("Invalid priority, must be one of: trivial, low, normal, high, critical.");
+        }
     }
 }
 

--- a/batch/src/client.rs
+++ b/batch/src/client.rs
@@ -3,6 +3,7 @@
 use std::iter::FromIterator;
 
 use futures::{future, Future};
+use lapin::channel::BasicProperties;
 use tokio_core::reactor::Handle;
 
 use error::{Error, ErrorKind};
@@ -124,8 +125,12 @@ impl Client {
     ///
     /// Once a job is sent to the message broker, it is transmitted to a Worker currently
     /// receiving jobs from the same broker.
-    pub(crate) fn send(&self, job: &Job) -> Box<Future<Item = (), Error = Error>> {
-        let task = self.broker.send(job);
+    pub(crate) fn send(
+        &self,
+        job: &Job,
+        properties: BasicProperties,
+    ) -> Box<Future<Item = (), Error = Error>> {
+        let task = self.broker.send(job, properties);
         Box::new(task)
     }
 }

--- a/batch/src/error.rs
+++ b/batch/src/error.rs
@@ -41,6 +41,10 @@ pub enum ErrorKind {
     #[fail(display = "This URL scheme is invalid: {}", _0)]
     InvalidScheme(::std::string::String),
 
+    /// The given priority is invalid, must be one of: trivial, low, normal, high, critical.
+    #[fail(display = "Invalid priority, must be one of: trivial, low, normal, high, critical.")]
+    InvalidPriority,
+
     /// An error occured in the RabbitMQ broker.
     #[fail(display = "An error occured in the RabbitMQ broker: {}", _0)]
     Rabbitmq(#[cause] ::std::io::Error),
@@ -96,6 +100,14 @@ impl Error {
     pub fn is_no_handle(&self) -> bool {
         match *self.kind() {
             ErrorKind::NoHandle => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if the error is from an invalid priority.
+    pub fn is_invalid_priority(&self) -> bool {
+        match *self.kind() {
+            ErrorKind::InvalidPriority => true,
             _ => false,
         }
     }

--- a/batch/src/job.rs
+++ b/batch/src/job.rs
@@ -95,14 +95,14 @@ where
         let serialized = ser::to_vec(&self.task)
             .map_err(error::ErrorKind::Serialization)
             .unwrap();
-        let job = Job {
-            uuid: Uuid::new_v4(),
-            name: String::from(T::name()),
-            queue: self.routing_key,
-            task: serialized,
-            timeout: self.timeout,
-            retries: self.retries,
-        };
+        let job = Job::new(
+            T::name(),
+            &self.exchange,
+            &self.routing_key,
+            &serialized,
+            self.timeout,
+            self.retries,
+        );
         client.send(&job, self.properties)
     }
 }
@@ -120,13 +120,34 @@ where
 pub struct Job {
     uuid: Uuid,
     name: String,
-    queue: String,
+    exchange: String,
+    routing_key: String,
     task: Vec<u8>,
     timeout: Option<Duration>,
     retries: u32,
 }
 
 impl Job {
+    /// Create a new Job.
+    pub(crate) fn new(
+        name: &str,
+        exchange: &str,
+        routing_key: &str,
+        task: &[u8],
+        timeout: Option<Duration>,
+        retries: u32,
+    ) -> Job {
+        Job {
+            uuid: Uuid::new_v4(),
+            name: name.to_string(),
+            exchange: exchange.to_string(),
+            routing_key: routing_key.to_string(),
+            task: task.to_vec(),
+            timeout,
+            retries,
+        }
+    }
+
     /// Returns the UUIDv4 of this job.
     pub fn uuid(&self) -> &Uuid {
         &self.uuid
@@ -137,9 +158,14 @@ impl Job {
         &self.name
     }
 
+    /// Returns the exchange this job should be sent to.
+    pub fn exchange(&self) -> &str {
+        &self.exchange
+    }
+
     /// Returns the queue this job should be pushed to.
-    pub fn queue(&self) -> &str {
-        &self.queue
+    pub fn routing_key(&self) -> &str {
+        &self.routing_key
     }
 
     /// Returns the raw serialized task this job is associated to.

--- a/batch/src/lib.rs
+++ b/batch/src/lib.rs
@@ -45,7 +45,9 @@
 //!         job(task).exchange("batch.example").send(&client)
 //!     });
 //!
+//! # if false {
 //!     core.run(send).unwrap();
+//! # }
 //! }
 //! ```
 
@@ -94,5 +96,5 @@ pub use client::{Client, ClientBuilder};
 pub use error::Error;
 pub use job::{job, Query};
 pub use rabbitmq::{exchange, queue, ExchangeBuilder, QueueBuilder};
-pub use task::{Perform, Task};
+pub use task::{Perform, Priority, Task};
 pub use worker::{Worker, WorkerBuilder};

--- a/batch/src/rabbitmq.rs
+++ b/batch/src/rabbitmq.rs
@@ -576,7 +576,7 @@ mod tests {
         let task = RabbitmqBroker::new_with_handle(
             conn_url,
             exchanges.clone(),
-            vec![],
+            queues.clone(),
             handle.clone(),
         ).and_then(|broker| {
             let tasks = jobs.iter().map(move |&(ref job, ref priority)| {

--- a/batch/src/rabbitmq.rs
+++ b/batch/src/rabbitmq.rs
@@ -544,3 +544,71 @@ impl QueueBuilder {
 pub fn queue(name: &str) -> QueueBuilder {
     QueueBuilder::new(name)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use task::Priority;
+
+    #[test]
+    fn priority_queue() {
+        let mut core = Core::new().unwrap();
+        let ex = "batch.tests.priorities";
+        let rk = "prioritised-hello";
+        let jobs = vec![
+            (Job::new("job-1", ex, rk, &[], None, 0), Priority::Normal),
+            (Job::new("job-2", ex, rk, &[], None, 0), Priority::Critical),
+            (Job::new("job-3", ex, rk, &[], None, 0), Priority::Trivial),
+            (Job::new("job-4", ex, rk, &[], None, 0), Priority::High),
+            (Job::new("job-5", ex, rk, &[], None, 0), Priority::Low),
+        ];
+        let expected = vec!["job-2", "job-4", "job-1", "job-5", "job-3"];
+
+        let conn_url = "amqp://localhost/%2f";
+        let exchanges = vec![exchange(ex).build()];
+        let queues = vec![
+            queue("tests.priorities")
+                .enable_priorities()
+                .bind(ex, rk)
+                .build(),
+        ];
+        let handle = core.handle();
+        let task = RabbitmqBroker::new_with_handle(
+            conn_url,
+            exchanges.clone(),
+            vec![],
+            handle.clone(),
+        ).and_then(|broker| {
+            let tasks = jobs.iter().map(move |&(ref job, ref priority)| {
+                let properties = BasicProperties {
+                    priority: Some(priority.to_u8()),
+                    ..Default::default()
+                };
+                broker.send(&job, properties)
+            });
+            future::join_all(tasks)
+        })
+            .and_then(move |_| RabbitmqBroker::new_with_handle(conn_url, exchanges, queues, handle))
+            .and_then(|broker| broker.recv())
+            .and_then(|consumer| {
+                future::loop_fn((consumer.into_future(), expected.clone()), |(f, order)| {
+                    f.map_err(|(e, _)| e)
+                        .and_then(move |(next, consumer)| {
+                            let head = order[0];
+                            let tail = order.into_iter().skip(1).collect::<Vec<_>>();
+                            let (uid, job) = next.unwrap();
+                            assert_eq!(job.name(), head);
+                            consumer.ack(uid).map(|_| (consumer, tail))
+                        })
+                        .and_then(|(consumer, order)| {
+                            if order.is_empty() {
+                                Ok(future::Loop::Break(()))
+                            } else {
+                                Ok(future::Loop::Continue((consumer.into_future(), order)))
+                            }
+                        })
+                })
+            });
+        core.run(task).unwrap();
+    }
+}

--- a/batch/src/rabbitmq.rs
+++ b/batch/src/rabbitmq.rs
@@ -227,8 +227,8 @@ impl RabbitmqBroker {
         };
         let task = channel
             .basic_publish(
-                "",
-                job.queue(),
+                job.exchange(),
+                job.routing_key(),
                 &serialized,
                 &BasicPublishOptions::default(),
                 properties,

--- a/batch/src/task.rs
+++ b/batch/src/task.rs
@@ -112,15 +112,6 @@ impl FromStr for Priority {
 
 impl Priority {
     /// Return the priority as a `u8` ranging from 0 to 4.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use batch::Priority;
-    ///
-    /// let p = Priority::Normal;
-    /// assert_eq!(p.to_u8(), 2);
-    /// ```
     pub(crate) fn to_u8(&self) -> u8 {
         match *self {
             Priority::Trivial => 0,

--- a/batch/src/task.rs
+++ b/batch/src/task.rs
@@ -121,7 +121,7 @@ impl Priority {
     /// let p = Priority::Normal;
     /// assert_eq!(p.to_u8(), 2);
     /// ```
-    pub fn to_u8(&self) -> u8 {
+    pub(crate) fn to_u8(&self) -> u8 {
         match *self {
             Priority::Trivial => 0,
             Priority::Low => 1,

--- a/batch/src/worker.rs
+++ b/batch/src/worker.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::{future, Future, IntoFuture, Stream};
+use lapin::channel::BasicProperties;
 use tokio_core::reactor::{Core, Handle};
 use wait_timeout::ChildExt;
 
@@ -381,7 +382,7 @@ fn reject(
     let task = consumer.reject(uid);
     if let Some(job) = job.failed() {
         debug!("[{}] Retry job after failure: {:?}", job.uuid(), job);
-        Box::new(task.and_then(move |_| broker.send(&job)))
+        Box::new(task.and_then(move |_| broker.send(&job, BasicProperties::default())))
     } else {
         task
     }

--- a/guide/src/tasks.md
+++ b/guide/src/tasks.md
@@ -32,7 +32,7 @@ This value is used to register and identify tasks in the worker, mapping a `task
 
 > **Default value**: empty string (default RabbitMQ exchange)
 
-This value is used when publishing a task to RabbitMQ. If you set a custom exchange name, you must ensure that it is declared before using it (see [`ClientBuilder::exchanges`](https://docs.rs/batch/0.1/batch/struct.ClientBuilder.html#method.exchanges)).
+This value is used when publishing a task to RabbitMQ. If you set a custom exchange name, you must ensure that it is declared before using it (see [`ClientBuilder::exchanges`]).
 
 ## `task_timeout` attribute
 
@@ -44,4 +44,13 @@ This attribute gives the number of seconds allowed before a task execution is co
 
 > **Default value**: 2
 
-The attribute gives the number of times a task should be tried again in case of failure. When a task is retried, it is pushed as a new task would be with the exact same attributes except for the `task_retries` attribute that gets decremented.
+This attribute gives the number of times a task should be tried again in case of failure. When a task is retried, it is pushed as a new task would be with the exact same attributes except for the `task_retries` attribute that gets decremented.
+
+## `task_priority` attribute
+
+> **Default value**: [`Priority::Normal`]
+
+This attribute is used to mark some jobs as more or less important than other and prioritize them for the consumer.
+
+[`ClientBuilder::exchanges`]: https://docs.rs/batch/0.1/batch/struct.ClientBuilder.html#method.exchanges
+[`Priority::Normal`]: https://docs.rs/batch/0.1/batch/enum.Priority.html


### PR DESCRIPTION
Uses RabbitMQ native support for message priorities. Still needs more docs before merging.

Fixes #8.