### PR TITLE
Prefix the generated task name by its module path

### DIFF
--- a/batch-codegen/src/lib.rs
+++ b/batch-codegen/src/lib.rs
@@ -56,7 +56,7 @@ pub fn task_derive(input: TokenStream) -> TokenStream {
         impl ::batch::Task for #name {
 
             fn name() -> &'static str {
-                #task_name
+                concat!(concat!(module_path!(), "::"), #task_name)
             }
 
             fn exchange() -> &'static str {


### PR DESCRIPTION
This change will avoid name collision between tasks that happen to
have the same name because they are not in the same module.

Fixes #9.