### PR TITLE
System dns resolution

### DIFF
--- a/batch/Cargo.toml
+++ b/batch/Cargo.toml
@@ -21,11 +21,13 @@ futures = "0.1.17"
 lapin-async = "0.10"
 lapin-futures = "0.10"
 log = "0.4"
+native-tls = "0.1"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 tokio-core = "0.1"
 tokio-io = "0.1"
+tokio-tls = "0.1"
 uuid = { version = "0.6", features = ["v4", "serde"] }
 wait-timeout = "0.1.5"
 

--- a/batch/Cargo.toml
+++ b/batch/Cargo.toml
@@ -14,17 +14,18 @@ categories = ["asynchronous"]
 travis-ci = { repository = "kureuil/batch-rs" }
 
 [dependencies]
+amq-protocol = "0.19"
+bytes = "0.4"
 failure = "0.1.1"
 futures = "0.1.17"
 lapin-async = "0.10"
 lapin-futures = "0.10"
-lapin-futures-rustls = "0.10"
-lapin-futures-tls-api = "0.6"
 log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 tokio-core = "0.1"
+tokio-io = "0.1"
 uuid = { version = "0.6", features = ["v4", "serde"] }
 wait-timeout = "0.1.5"
 

--- a/batch/src/error.rs
+++ b/batch/src/error.rs
@@ -48,6 +48,10 @@ pub enum ErrorKind {
     /// An error occured in the RabbitMQ broker.
     #[fail(display = "An error occured in the RabbitMQ broker: {}", _0)]
     Rabbitmq(#[cause] ::std::io::Error),
+
+    /// An error occured while setting up TLS.
+    #[fail(display = "An error occured while setting up TLS: {}", _0)]
+    Tls(#[cause] ::native_tls::Error),
 }
 
 impl Error {
@@ -124,6 +128,14 @@ impl Error {
     pub fn is_rabbitmq(&self) -> bool {
         match *self.kind() {
             ErrorKind::Rabbitmq(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if the error is from the TLS stack.
+    pub fn is_tls(&self) -> bool {
+        match *self.kind() {
+            ErrorKind::Tls(_) => true,
             _ => false,
         }
     }

--- a/batch/src/error.rs
+++ b/batch/src/error.rs
@@ -38,8 +38,8 @@ pub enum ErrorKind {
     NoHandle,
 
     /// The given URL's scheme is not handled.
-    #[fail(display = "This URL scheme is invalid: {}", _0)]
-    InvalidScheme(::std::string::String),
+    #[fail(display = "The given connection URL is invalid: {}", _0)]
+    InvalidUrl(::std::string::String),
 
     /// The given priority is invalid, must be one of: trivial, low, normal, high, critical.
     #[fail(display = "Invalid priority, must be one of: trivial, low, normal, high, critical.")]
@@ -100,6 +100,14 @@ impl Error {
     pub fn is_no_handle(&self) -> bool {
         match *self.kind() {
             ErrorKind::NoHandle => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if the error is from an invalid scheme in the connection URL.
+    pub fn is_invalid_url(&self) -> bool {
+        match *self.kind() {
+            ErrorKind::InvalidUrl(_) => true,
             _ => false,
         }
     }

--- a/batch/src/lib.rs
+++ b/batch/src/lib.rs
@@ -73,12 +73,14 @@ extern crate lapin_async;
 extern crate lapin_futures as lapin;
 #[macro_use]
 extern crate log;
+extern crate native_tls;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
 extern crate tokio_core;
 extern crate tokio_io;
+extern crate tokio_tls;
 extern crate uuid;
 extern crate wait_timeout;
 

--- a/batch/src/lib.rs
+++ b/batch/src/lib.rs
@@ -64,13 +64,13 @@
 #![allow(unused_imports)]
 #![allow(unknown_lints)]
 
+extern crate amq_protocol;
+extern crate bytes;
 #[macro_use]
 extern crate failure;
 extern crate futures;
 extern crate lapin_async;
 extern crate lapin_futures as lapin;
-extern crate lapin_futures_rustls as lapin_rustls;
-extern crate lapin_futures_tls_api as lapin_tls_api;
 #[macro_use]
 extern crate log;
 extern crate serde;
@@ -78,6 +78,7 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 extern crate tokio_core;
+extern crate tokio_io;
 extern crate uuid;
 extern crate wait_timeout;
 

--- a/batch/src/rabbitmq.rs
+++ b/batch/src/rabbitmq.rs
@@ -3,33 +3,35 @@
 use std::collections::BTreeSet;
 use std::cmp;
 use std::fmt;
-use std::io;
+use std::io::{self, Read, Write};
 use std::iter::FromIterator;
 use std::net::{self, ToSocketAddrs};
 use std::result::Result as StdResult;
+use std::str::FromStr;
 use std::thread;
 
-use futures::{future, Async, Future, IntoFuture, Poll, Stream};
+use amq_protocol::uri::AMQPUri;
+use bytes::{Buf, BufMut};
+use futures::{self, future, Async, Future, IntoFuture, Poll};
 use lapin::channel::{BasicConsumeOptions, BasicProperties, BasicPublishOptions, Channel,
                      ExchangeBindOptions, ExchangeDeclareOptions, QueueBindOptions,
                      QueueDeclareOptions};
 use lapin::client::{Client, ConnectionOptions};
 use lapin::types::{AMQPValue, FieldTable};
 use lapin_async::queue::Message;
-use lapin_rustls::AMQPConnectionRustlsExt;
-use lapin_tls_api::AMQPStream;
 use tokio_core::reactor::{Core, Handle};
 use tokio_core::net::TcpStream;
+use tokio_io::{AsyncRead, AsyncWrite};
 
 use de;
-use error::{Error, ErrorKind};
+use error::{Error, ErrorKind, Result};
 use job::Job;
 use ser;
 
 /// Declare the given queues to the given `Channel`.
 fn declare_queues<Q>(
     queues: Q,
-    channel: Channel<AMQPStream>,
+    channel: Channel<Stream>,
 ) -> Box<Future<Item = (), Error = io::Error>>
 where
     Q: IntoIterator<Item = Queue> + 'static,
@@ -65,7 +67,7 @@ where
 /// Declare the given exchanges to the given `Channel`.
 fn declare_exchanges<E>(
     exchanges: E,
-    channel: Channel<AMQPStream>,
+    channel: Channel<Stream>,
 ) -> Box<Future<Item = (), Error = io::Error>>
 where
     E: IntoIterator<Item = Exchange> + 'static,
@@ -108,8 +110,8 @@ where
 pub struct RabbitmqBroker {
     exchanges: Vec<Exchange>,
     queues: Vec<Queue>,
-    publish_channel: Channel<AMQPStream>,
-    client: Client<AMQPStream>,
+    publish_channel: Channel<Stream>,
+    client: Client<Stream>,
 }
 
 impl fmt::Debug for RabbitmqBroker {
@@ -120,6 +122,105 @@ impl fmt::Debug for RabbitmqBroker {
             self.exchanges, self.queues
         )
     }
+}
+
+enum Stream {
+    Raw(::tokio_core::net::TcpStream),
+}
+
+impl Read for Stream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match *self {
+            Stream::Raw(ref mut raw) => raw.read(buf),
+        }
+    }
+}
+
+impl AsyncRead for Stream {
+    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
+        match *self {
+            Stream::Raw(ref raw) => raw.prepare_uninitialized_buffer(buf),
+        }
+    }
+
+    fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+        match *self {
+            Stream::Raw(ref mut raw) => raw.read_buf(buf),
+        }
+    }
+}
+
+impl Write for Stream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match *self {
+            Stream::Raw(ref mut raw) => raw.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match *self {
+            Stream::Raw(ref mut raw) => raw.flush(),
+        }
+    }
+}
+
+impl AsyncWrite for Stream {
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        match *self {
+            Stream::Raw(ref mut raw) => raw.shutdown(),
+        }
+    }
+
+    fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
+        match *self {
+            Stream::Raw(ref mut raw) => raw.write_buf(buf),
+        }
+    }
+}
+
+fn connect(
+    connection_url: &str,
+    handle: Handle,
+) -> Box<Future<Item = Client<Stream>, Error = Error>> {
+    let heartbeat_handle = handle.clone();
+    let task = AMQPUri::from_str(connection_url)
+        .map_err(|e| ErrorKind::InvalidUrl(e).into())
+        .into_future()
+        .and_then(|uri| {
+            let addr_uri = uri.clone();
+            let addr = (addr_uri.authority.host.as_ref(), addr_uri.authority.port);
+            net::TcpStream::connect(addr)
+                .map_err(|e| ErrorKind::Io(e).into())
+                .into_future()
+                .join(future::ok(uri))
+        })
+        .and_then(move |(stream, uri)| {
+            TcpStream::from_stream(stream, &handle)
+                .map(|stream| Stream::Raw(stream))
+                .map_err(|e| ErrorKind::Io(e).into())
+                .into_future()
+                .join(future::ok(uri))
+        })
+        .and_then(move |(stream, uri)| {
+            let opts = ConnectionOptions {
+                username: uri.authority.userinfo.username,
+                password: uri.authority.userinfo.password,
+                vhost: uri.vhost,
+                frame_max: uri.query.frame_max.unwrap_or(0),
+                heartbeat: uri.query.heartbeat.unwrap_or(0),
+            };
+            Client::connect(stream, &opts)
+                .map_err(|e| ErrorKind::Rabbitmq(e).into())
+                .map(move |(client, heartbeat_fn)| {
+                    let heartbeat_client = client.clone();
+                    heartbeat_handle.spawn(
+                        heartbeat_fn(&heartbeat_client)
+                            .map_err(|e| eprintln!("RabbitMQ heartbeat error: {}", e)),
+                    );
+                    client
+                })
+        });
+    Box::new(task)
 }
 
 impl RabbitmqBroker {
@@ -140,21 +241,24 @@ impl RabbitmqBroker {
         let queues = queues_iter.into_iter().collect::<Vec<_>>();
         let queues_ = queues.clone();
 
-        let task = connection_url
-            .connect(handle, |err| {
-                error!(
-                    "An error occured in the RabbitMQ heartbeat handler: {}",
-                    err
-                )
-            })
-            .and_then(|client| client.create_channel().join(future::ok(client)))
-            .and_then(move |(channel, client)| {
-                let channel_ = channel.clone();
-                declare_exchanges(exchanges_, channel).map(|_| (channel_, client))
+        let task = connect(connection_url, handle)
+            .and_then(|client| {
+                client
+                    .create_channel()
+                    .map_err(|e| ErrorKind::Rabbitmq(e).into())
+                    .join(future::ok(client))
             })
             .and_then(move |(channel, client)| {
                 let channel_ = channel.clone();
-                declare_queues(queues_, channel).map(|_| (channel_, client))
+                declare_exchanges(exchanges_, channel)
+                    .map_err(|e| ErrorKind::Rabbitmq(e).into())
+                    .map(|_| (channel_, client))
+            })
+            .and_then(move |(channel, client)| {
+                let channel_ = channel.clone();
+                declare_queues(queues_, channel)
+                    .map_err(|e| ErrorKind::Rabbitmq(e).into())
+                    .map(|_| (channel_, client))
             })
             .and_then(move |(publish_channel, client)| {
                 future::ok(RabbitmqBroker {
@@ -163,8 +267,7 @@ impl RabbitmqBroker {
                     queues,
                     exchanges,
                 })
-            })
-            .map_err(|e| ErrorKind::Rabbitmq(e).into());
+            });
         Box::new(task)
     }
 
@@ -198,11 +301,12 @@ impl RabbitmqBroker {
                 })).join(future::ok(channel))
             })
             .and_then(|(mut consumers, channel)| {
-                let initial: Box<Stream<Item = Message, Error = io::Error> + Send> =
-                    Box::new(consumers.pop().unwrap());
-                let consumer = consumers
-                    .into_iter()
-                    .fold(initial, |acc, consumer| Box::new(acc.select(consumer)));
+                let initial: Box<
+                    futures::Stream<Item = Message, Error = io::Error> + Send,
+                > = Box::new(consumers.pop().unwrap());
+                let consumer = consumers.into_iter().fold(initial, |acc, consumer| {
+                    Box::new(futures::Stream::select(acc, consumer))
+                });
                 future::ok(RabbitmqConsumer {
                     channel,
                     stream: consumer,
@@ -245,8 +349,8 @@ impl RabbitmqBroker {
 /// The type of the stream is a tuple containing a `u64` which is a unique ID for the
 /// job used when `ack`'ing or `reject`'ing it, and a `Job` instance.
 pub struct RabbitmqConsumer {
-    channel: Channel<AMQPStream>,
-    stream: Box<Stream<Item = Message, Error = io::Error> + Send>,
+    channel: Channel<Stream>,
+    stream: Box<futures::Stream<Item = Message, Error = io::Error> + Send>,
 }
 
 impl fmt::Debug for RabbitmqConsumer {
@@ -277,7 +381,7 @@ impl RabbitmqConsumer {
     }
 }
 
-impl Stream for RabbitmqConsumer {
+impl futures::Stream for RabbitmqConsumer {
     type Item = (u64, Job);
     type Error = Error;
 
@@ -731,6 +835,7 @@ mod tests {
 
     #[test]
     fn priority_queue() {
+        use futures::Stream;
         let mut core = Core::new().unwrap();
         let ex = "batch.tests.priorities";
         let rk = "prioritised-hello";

--- a/batch/src/worker.rs
+++ b/batch/src/worker.rs
@@ -30,7 +30,7 @@ use error::{self, Result};
 use de;
 use ser;
 use job::{Failure as JobFailure, Job, Status as JobStatus};
-use rabbitmq::{Exchange, ExchangeBuilder, Queue, QueueBuilder, RabbitmqBroker, RabbitmqStream};
+use rabbitmq::{Exchange, ExchangeBuilder, Queue, QueueBuilder, RabbitmqBroker, RabbitmqConsumer};
 use task::{Perform, Task};
 
 /// Type of task handlers stored in `Worker`.
@@ -388,7 +388,7 @@ impl<Ctx> Worker<Ctx> {
 }
 
 fn reject(
-    consumer: &RabbitmqStream,
+    consumer: &RabbitmqConsumer,
     broker: Arc<RabbitmqBroker>,
     uid: u64,
     job: Job,


### PR DESCRIPTION
Replace lapin-futures-tls-api by homegrown code using: the system DNS resolver, and native-tls for the AMQPS protocol. This is the prelimianry step for both #4 & #5.