### PR TITLE
Fix manual task name

### DIFF
--- a/batch-codegen/src/lib.rs
+++ b/batch-codegen/src/lib.rs
@@ -56,7 +56,7 @@ pub fn task_derive(input: TokenStream) -> TokenStream {
         impl ::batch::Task for #name {
 
             fn name() -> &'static str {
-                concat!(concat!(module_path!(), "::"), #task_name)
+                #task_name
             }
 
             fn exchange() -> &'static str {
@@ -84,11 +84,14 @@ pub fn task_derive(input: TokenStream) -> TokenStream {
 }
 
 fn get_derive_name_attr(input: &DeriveInput) -> Tokens {
-    let attr = {
-        let raw = get_str_attr_by_name(&input.attrs, "task_name");
-        raw.unwrap_or_else(|| input.ident.as_ref().to_string())
-    };
-    attr.into_tokens()
+    if let Some(raw) = get_str_attr_by_name(&input.attrs, "task_name") {
+        raw.into_tokens()
+    } else {
+        let name = input.ident.as_ref();
+        quote! {
+            concat!(concat!(module_path!(), "::"), #name)
+        }
+    }
 }
 
 fn get_derive_exchange_attr(input: &DeriveInput) -> Tokens {

--- a/batch/examples/simple-client.rs
+++ b/batch/examples/simple-client.rs
@@ -12,6 +12,7 @@ use futures::Future;
 use tokio_core::reactor::Core;
 
 #[derive(Serialize, Deserialize, Task)]
+#[task_name = "batch::SayHello"]
 #[task_routing_key = "hello-world"]
 struct SayHello {
     to: String,

--- a/batch/examples/simple-worker.rs
+++ b/batch/examples/simple-worker.rs
@@ -10,6 +10,7 @@ use batch::{exchange, queue, Perform, WorkerBuilder};
 use tokio_core::reactor::Core;
 
 #[derive(Serialize, Deserialize, Task)]
+#[task_name = "batch::SayHello"]
 #[task_routing_key = "hello-world"]
 struct SayHello {
     to: String,


### PR DESCRIPTION
If you manually specified a name for a `Task`, it would be prepended by the `Task`'s module path breaking the feature when use for cross-crate collaboration.