### PR TITLE
Refactor task name generation to use dots instead of double colons

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ Add this to your `Cargo.toml`:
 batch = "0.1"
 ```
 
-> **Note**: Task serialization depends on [`serde`](https://serde.rs/), so you will have to add it to your project's dependencies as well.
+> **Note**: Task serialization depends on [`serde`](https://serde.rs/) & [`lazy_static`](https://crates.io/crates/lazy_static), so you will have to add them to your project's dependencies as well.
 
 Then add this to your crate root:
 
 ```rust
 #[macro_use]
 extern crate batch;
+#[macro_use]
+extern crate lazy_static;
 ```
 
 Examples are available on [GitHub][gh-examples] or you can continue and read the [Getting Started][getting-started] guide.

--- a/batch-codegen/Cargo.toml
+++ b/batch-codegen/Cargo.toml
@@ -10,8 +10,9 @@ authors = ["Louis Person <louis@person.guru>"]
 proc-macro = true
 
 [dependencies]
-syn = "0.12"
-quote = "0.4"
+syn = "0.14"
+quote = "0.6"
+proc-macro2 = "0.4"
 
 [features]
 default = []

--- a/batch/Cargo.toml
+++ b/batch/Cargo.toml
@@ -22,8 +22,7 @@ lapin-futures = "0.12"
 log = "0.4"
 native-tls = "0.1"
 num_cpus = "1.0"
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio-executor = "0.1"
 tokio-io = "0.1"
@@ -37,6 +36,7 @@ batch-codegen = { version = "0.1", path = "../batch-codegen", optional = true }
 
 [dev-dependencies]
 env_logger = "0.5"
+lazy_static = "1.0"
 tokio = "0.1"
 
 [features]

--- a/batch/examples/simple-client.rs
+++ b/batch/examples/simple-client.rs
@@ -2,9 +2,10 @@
 extern crate batch;
 extern crate env_logger;
 extern crate futures;
-extern crate serde;
 #[macro_use]
-extern crate serde_derive;
+extern crate lazy_static;
+#[macro_use]
+extern crate serde;
 extern crate tokio;
 
 use batch::{exchange, job, queue, ClientBuilder};

--- a/batch/examples/simple-worker.rs
+++ b/batch/examples/simple-worker.rs
@@ -2,9 +2,10 @@
 extern crate batch;
 extern crate env_logger;
 extern crate futures;
-extern crate serde;
 #[macro_use]
-extern crate serde_derive;
+extern crate lazy_static;
+#[macro_use]
+extern crate serde;
 extern crate tokio;
 
 use batch::{exchange, queue, Perform, WorkerBuilder};

--- a/batch/src/lib.rs
+++ b/batch/src/lib.rs
@@ -11,9 +11,10 @@
 //! extern crate batch;
 //! # extern crate failure;
 //! extern crate futures;
-//! extern crate serde;
 //! #[macro_use]
-//! extern crate serde_derive;
+//! extern crate lazy_static;
+//! #[macro_use]
+//! extern crate serde;
 //! extern crate tokio;
 //!
 //! use batch::{exchange, job, ClientBuilder};
@@ -66,9 +67,8 @@ extern crate lapin_futures as lapin;
 extern crate log;
 extern crate native_tls;
 extern crate num_cpus;
-extern crate serde;
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 extern crate serde_json;
 #[cfg(test)]
 extern crate tokio;

--- a/batch/src/task.rs
+++ b/batch/src/task.rs
@@ -3,8 +3,8 @@
 use std::str::FromStr;
 use std::time::Duration;
 
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 use error::{Error, ErrorKind, Result};
 
@@ -19,9 +19,10 @@ use error::{Error, ErrorKind, Result};
 /// ```rust
 /// #[macro_use]
 /// extern crate batch;
-/// extern crate serde;
 /// #[macro_use]
-/// extern crate serde_derive;
+/// extern crate lazy_static;
+/// #[macro_use]
+/// extern crate serde;
 ///
 /// #[derive(Deserialize, Serialize, Task)]
 /// #[task_routing_key = "emails"]
@@ -36,9 +37,10 @@ use error::{Error, ErrorKind, Result};
 /// ```rust
 /// #[macro_use]
 /// extern crate batch;
-/// extern crate serde;
 /// #[macro_use]
-/// extern crate serde_derive;
+/// extern crate lazy_static;
+/// #[macro_use]
+/// extern crate serde;
 ///
 /// struct App;
 ///
@@ -130,9 +132,10 @@ impl Priority {
 /// ```
 /// #[macro_use]
 /// extern crate batch;
-/// extern crate serde;
 /// #[macro_use]
-/// extern crate serde_derive;
+/// extern crate lazy_static;
+/// #[macro_use]
+/// extern crate serde;
 ///
 /// use batch::Perform;
 ///

--- a/batch/src/worker.rs
+++ b/batch/src/worker.rs
@@ -185,9 +185,10 @@ impl<Ctx> WorkerBuilder<Ctx> {
     /// ```
     /// # #[macro_use]
     /// # extern crate batch;
-    /// # extern crate serde;
+    /// #[macro_use]
+    /// extern crate lazy_static;
     /// # #[macro_use]
-    /// # extern crate serde_derive;
+    /// # extern crate serde;
     /// #
     /// use batch::{Perform, WorkerBuilder};
     ///


### PR DESCRIPTION
Fixes #43

The task names generated by the derive procedural macro were the raw
path to the derived struct (e.g: `test::web::SendSignupEmail`) but this
task name format isn't common, unlike the established standard of separating
path components with dots (e.g: `test.web.SendSignupEmail`) which is
very useful when you want to use wildcards when listening for events.

Dependencies were upgraded to their latest versions:

* syn: 0.14
* quote: 0.6
* proc_macro2: 0.4