### PR TITLE
Pin mdbook-linkcheck to version 0.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
   - rust: nightly
     env: ROLE=guide
     script:
-    - export MDBOOK_VERSION=0.2.2
+    - export MDBOOK_VERSION=0.2.1
     - "wget -O mdbook.tar.gz https://github.com/rust-lang-nursery/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz"
     - tar xf mdbook.tar.gz
     - cargo build --all --all-features
@@ -68,10 +68,10 @@ script:
 - cargo test --all --all-features
 
 before_deploy:
-- export MDBOOK_VERSION=0.2.2
+- export MDBOOK_VERSION=0.2.1
 - "wget -O mdbook.tar.gz https://github.com/rust-lang-nursery/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz"
 - tar xf mdbook.tar.gz
-- cargo install mdbook-linkcheck
+- cargo install mdbook-linkcheck --version 0.2.2
 - ./mdbook build ./guide
 
 deploy:


### PR DESCRIPTION
The latest release of mdbook-linkcheck (v0.2.3) depends on mdbook 0.2.2
being installed, but this release didn't have any precompiled binaries
artifacts making it impossible to install it using only `wget` & `tar`.

This commit pins these programs to versions with precompiled binaries
known to work together.