### PR TITLE
Convert crates to Rust 2018 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 ]
 
 [package]
+edition = "2018"
 name = "batch"
 description = "Safe & extensible background job library supporting RabbitMQ"
 homepage = "https://kureuil.github.io/batch-rs/"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Batch allows you to defer jobs to worker processes, by sending messages to a bro
 
 ## Installation
 
-**Minimum Rust Version:** 1.30
+**Minimum Rust Version:** 1.31
 
 Add this to your `Cargo.toml`:
 
@@ -26,6 +26,7 @@ Add this to your `Cargo.toml`:
 batch = "0.2"
 ```
 
+**Only if you're using Rust 2015 edition**  
 Then add this to your crate root:
 
 ```rust
@@ -35,10 +36,6 @@ extern crate batch;
 ## Batch in action
 
 ```rust
-extern crate batch;
-extern crate batch_rabbitmq;
-extern crate tokio;
-
 use batch::job;
 use batch_rabbitmq::{queues, Connection};
 use std::path::PathBuf;

--- a/batch-codegen/Cargo.toml
+++ b/batch-codegen/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "batch-codegen"
 description = "Batch's procedural macros"
 repository = "https://github.com/kureuil/batch-rs"

--- a/batch-codegen/src/job.rs
+++ b/batch-codegen/src/job.rs
@@ -1,17 +1,15 @@
 use std::collections::HashSet;
 
-use humantime;
-use proc_macro;
 use proc_macro2::{Span, TokenStream};
-use quote::ToTokens;
+use quote::{quote, quote_spanned, ToTokens};
 use std::time::Duration;
-use syn;
+use syn::{bracketed, parse_quote, Token};
 use syn::parse;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::visit_mut::VisitMut;
 
-use error::Error;
+use crate::error::Error;
 
 #[derive(Clone)]
 struct JobAttrs {
@@ -121,12 +119,12 @@ impl parse::Parse for JobAttrs {
 }
 
 mod kw {
-    custom_keyword!(name);
-    custom_keyword!(wrapper);
-    custom_keyword!(inject);
-    custom_keyword!(retries);
-    custom_keyword!(timeout);
-    custom_keyword!(priority);
+    syn::custom_keyword!(name);
+    syn::custom_keyword!(wrapper);
+    syn::custom_keyword!(inject);
+    syn::custom_keyword!(retries);
+    syn::custom_keyword!(timeout);
+    syn::custom_keyword!(priority);
 }
 
 impl parse::Parse for JobAttr {
@@ -171,11 +169,11 @@ impl parse::Parse for JobAttr {
 }
 
 mod priorities {
-    custom_keyword!(trivial);
-    custom_keyword!(low);
-    custom_keyword!(normal);
-    custom_keyword!(high);
-    custom_keyword!(critical);
+    syn::custom_keyword!(trivial);
+    syn::custom_keyword!(low);
+    syn::custom_keyword!(normal);
+    syn::custom_keyword!(high);
+    syn::custom_keyword!(critical);
 }
 
 impl parse::Parse for Priority {
@@ -508,8 +506,8 @@ pub(crate) fn impl_macro(
     args: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let attrs = parse_macro_input!(args as JobAttrs);
-    let mut item = parse_macro_input!(input as syn::ItemFn);
+    let attrs = syn::parse_macro_input!(args as JobAttrs);
+    let mut item = syn::parse_macro_input!(input as syn::ItemFn);
     let mut job = match Job::new(attrs) {
         Ok(job) => job,
         Err(e) => return quote!(#e).into(),

--- a/batch-codegen/src/job.rs
+++ b/batch-codegen/src/job.rs
@@ -3,11 +3,11 @@ use std::collections::HashSet;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 use std::time::Duration;
-use syn::{bracketed, parse_quote, Token};
 use syn::parse;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::visit_mut::VisitMut;
+use syn::{bracketed, parse_quote, Token};
 
 use crate::error::Error;
 
@@ -59,7 +59,8 @@ impl JobAttrs {
             .filter_map(|a| match a {
                 JobAttr::Name(s) => Some(s.value()),
                 _ => None,
-            }).next()
+            })
+            .next()
     }
 
     fn wrapper(&self) -> Option<syn::Ident> {
@@ -68,7 +69,8 @@ impl JobAttrs {
             .filter_map(|a| match a {
                 JobAttr::Wrapper(i) => Some(i.clone()),
                 _ => None,
-            }).next()
+            })
+            .next()
     }
 
     fn inject(&self) -> HashSet<syn::Ident> {
@@ -77,7 +79,8 @@ impl JobAttrs {
             .filter_map(|a| match a {
                 JobAttr::Inject(i) => Some(i.clone()),
                 _ => None,
-            }).next()
+            })
+            .next()
             .unwrap_or_else(HashSet::new)
     }
 
@@ -87,7 +90,8 @@ impl JobAttrs {
             .filter_map(|a| match a {
                 JobAttr::Retries(r) => Some(r.clone()),
                 _ => None,
-            }).next()
+            })
+            .next()
     }
 
     fn timeout(&self) -> Option<(syn::LitStr, Duration)> {
@@ -96,7 +100,8 @@ impl JobAttrs {
             .filter_map(|a| match a {
                 JobAttr::Timeout(r, p) => Some((r.clone(), p.clone())),
                 _ => None,
-            }).next()
+            })
+            .next()
     }
 
     fn priority(&self) -> Option<Priority> {
@@ -105,7 +110,8 @@ impl JobAttrs {
             .filter_map(|a| match a {
                 JobAttr::Priority(p) => Some(p.clone()),
                 _ => None,
-            }).next()
+            })
+            .next()
     }
 }
 
@@ -519,7 +525,8 @@ pub(crate) fn impl_macro(
             .fold(TokenStream::new(), |mut acc, err| {
                 err.to_tokens(&mut acc);
                 acc
-            }).into()
+            })
+            .into()
     } else {
         let output = quote! {
             #job

--- a/batch-codegen/src/lib.rs
+++ b/batch-codegen/src/lib.rs
@@ -11,13 +11,8 @@
 #![doc(html_root_url = "https://docs.rs/batch-codegen/0.2.0")]
 #![deny(missing_debug_implementations)]
 
-extern crate humantime;
+// Still needed despite Rust 2018 edition.
 extern crate proc_macro;
-extern crate proc_macro2;
-#[macro_use]
-extern crate quote;
-#[macro_use]
-extern crate syn;
 
 mod error;
 mod job;

--- a/batch-rabbitmq-codegen/Cargo.toml
+++ b/batch-rabbitmq-codegen/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "batch-rabbitmq-codegen"
 description = "Batch's RabbitMQ specific procedural macros"
 repository = "https://github.com/kureuil/batch-rs"

--- a/batch-rabbitmq-codegen/src/lib.rs
+++ b/batch-rabbitmq-codegen/src/lib.rs
@@ -4,12 +4,8 @@
 #![doc(html_root_url = "https://docs.rs/batch-rabbitmq-codegen/0.2.0")]
 #![deny(missing_debug_implementations)]
 
+// Still needed despite Rust 2018 edition.
 extern crate proc_macro;
-extern crate proc_macro2;
-#[macro_use]
-extern crate quote;
-#[macro_use]
-extern crate syn;
 
 use proc_macro::TokenStream;
 

--- a/batch-rabbitmq-codegen/src/queues.rs
+++ b/batch-rabbitmq-codegen/src/queues.rs
@@ -1,8 +1,8 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
-use syn::{braced, bracketed, Token};
 use syn::parse;
 use syn::punctuated::Punctuated;
+use syn::{braced, bracketed, Token};
 
 use crate::error::Error;
 
@@ -54,7 +54,8 @@ impl QueueAttrs {
             .filter_map(|a| match a {
                 QueueAttr::Name(s) => Some(s.clone()),
                 _ => None,
-            }).next()
+            })
+            .next()
     }
 
     fn with_priorities(&self) -> bool {
@@ -63,7 +64,8 @@ impl QueueAttrs {
             .filter_map(|a| match a {
                 QueueAttr::WithPriorities(p) => Some(p.value),
                 _ => None,
-            }).next()
+            })
+            .next()
             .unwrap_or(false)
     }
 
@@ -73,7 +75,8 @@ impl QueueAttrs {
             .filter_map(|a| match a {
                 QueueAttr::Exclusive(e) => Some(e.value),
                 _ => None,
-            }).next()
+            })
+            .next()
             .unwrap_or(false)
     }
 
@@ -83,7 +86,8 @@ impl QueueAttrs {
             .filter_map(|a| match a {
                 QueueAttr::Bindings(b) => Some(b.clone()),
                 _ => None,
-            }).next()
+            })
+            .next()
             .unwrap_or_else(QueueBindings::default)
     }
 
@@ -93,7 +97,8 @@ impl QueueAttrs {
             .filter_map(|a| match a {
                 QueueAttr::Exchange(s) => Some(s.clone()),
                 _ => None,
-            }).next()
+            })
+            .next()
     }
 }
 

--- a/batch-rabbitmq-codegen/src/queues.rs
+++ b/batch-rabbitmq-codegen/src/queues.rs
@@ -1,11 +1,10 @@
-use proc_macro;
 use proc_macro2::{Span, TokenStream};
-use quote::ToTokens;
-use syn;
+use quote::{quote, ToTokens};
+use syn::{braced, bracketed, Token};
 use syn::parse;
 use syn::punctuated::Punctuated;
 
-use error::Error;
+use crate::error::Error;
 
 struct QueueAttrsList(Vec<QueueAttrs>);
 
@@ -122,11 +121,11 @@ impl parse::Parse for QueueAttrs {
 }
 
 mod kw {
-    custom_keyword!(name);
-    custom_keyword!(with_priorities);
-    custom_keyword!(exclusive);
-    custom_keyword!(bindings);
-    custom_keyword!(exchange);
+    syn::custom_keyword!(name);
+    syn::custom_keyword!(with_priorities);
+    syn::custom_keyword!(exclusive);
+    syn::custom_keyword!(bindings);
+    syn::custom_keyword!(exchange);
 }
 
 impl parse::Parse for QueueAttr {
@@ -275,7 +274,7 @@ fn do_parse(attrs: impl Iterator<Item = QueueAttrs>) -> Result<Vec<Queue>, Error
 }
 
 pub(crate) fn impl_macro(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let attrs = parse_macro_input!(input as QueueAttrsList);
+    let attrs = syn::parse_macro_input!(input as QueueAttrsList);
     let queues = match do_parse(attrs.into_iter()) {
         Ok(queues) => queues,
         Err(e) => {

--- a/batch-rabbitmq/Cargo.toml
+++ b/batch-rabbitmq/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "batch-rabbitmq"
 description = "Rabbitmq adapter for batch"
 repository = "https://github.com/kureuil/batch-rs"
@@ -14,7 +15,7 @@ bytes = "0.4"
 failure = "0.1"
 futures = "0.1"
 lapin-async = "0.14"
-lapin-futures = "0.14"
+lapin = { version = "0.14", package = "lapin-futures" }
 log = "0.4"
 native-tls = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/batch-rabbitmq/src/connection.rs
+++ b/batch-rabbitmq/src/connection.rs
@@ -158,7 +158,8 @@ impl<'u> Builder<'u> {
                     heartbeat: uri.query.heartbeat.unwrap_or(0),
                 };
                 Client::connect(stream, opts).map_err(|e| e.into())
-            }).and_then(move |(client, mut heartbeat)| {
+            })
+            .and_then(move |(client, mut heartbeat)| {
                 let handle = HeartbeatHandle(heartbeat.handle());
                 log::trace!("Spawning RabbitMQ heartbeat future");
                 spawn(heartbeat.map_err(|e| {
@@ -168,7 +169,8 @@ impl<'u> Builder<'u> {
                     .create_channel()
                     .map(|channel| (client, channel, handle))
                     .map_err(Error::from)
-            }).and_then(move |(client, channel, handle)| {
+            })
+            .and_then(move |(client, channel, handle)| {
                 let channel2 = channel.clone();
                 let tasks: Vec<_> = queues2
                     .into_iter()
@@ -179,18 +181,20 @@ impl<'u> Builder<'u> {
                                 queue.exchange().kind().as_ref(),
                                 ExchangeDeclareOptions::default(),
                                 FieldTable::new(),
-                            ).map(|_| ())
+                            )
+                            .map(|_| ())
                             .map_err(Error::from);
                         Box::new(task) as Box<Future<Item = (), Error = Error> + Send>
-                    }).collect();
+                    })
+                    .collect();
                 future::join_all(tasks).map(move |_| (client, channel, handle))
-            }).map(move |(client, channel, handle)| {
+            })
+            .map(move |(client, channel, handle)| {
                 let (publisher, consumer) = mpsc::channel(1024);
                 let (publish_task, publish_handle) = Publisher::new(channel.clone(), consumer);
-                spawn(
-                    publish_task
-                        .map_err(|e| log::error!("An error occured while processing dispatches: {}", e)),
-                );
+                spawn(publish_task.map_err(|e| {
+                    log::error!("An error occured while processing dispatches: {}", e)
+                }));
                 let inner = Inner {
                     _channel: channel,
                     _handle: handle,
@@ -353,13 +357,16 @@ impl batch::Client for Connection {
                                 queue.exchange().kind().as_ref(),
                                 ExchangeDeclareOptions::default(),
                                 FieldTable::new(),
-                            ).map(|_| (name, queue))
+                            )
+                            .map(|_| (name, queue))
                             .map_err(Error::from);
                         Box::new(task)
                             as Box<Future<Item = (String, queue::Queue), Error = Error> + Send>
-                    }).collect();
+                    })
+                    .collect();
                 future::join_all(tasks).map(|queues| (channel, queues))
-            }).and_then(move |(channel, queues)| {
+            })
+            .and_then(move |(channel, queues)| {
                 let tasks: Vec<_> = queues
                     .iter()
                     .map(|(_, queue)| {
@@ -368,11 +375,14 @@ impl batch::Client for Connection {
                                 queue.name(),
                                 QueueDeclareOptions::default(),
                                 FieldTable::new(),
-                            ).map_err(Error::from);
+                            )
+                            .map_err(Error::from);
                         Box::new(task) as Box<Future<Item = Queue, Error = Error> + Send>
-                    }).collect();
+                    })
+                    .collect();
                 future::join_all(tasks).map(|declared| (channel, queues, declared))
-            }).and_then(move |(channel, queues, declared)| {
+            })
+            .and_then(move |(channel, queues, declared)| {
                 let mut tasks = vec![];
                 for (_, queue) in queues {
                     for job in queue.callbacks().map(|(k, _v)| k) {
@@ -383,13 +393,15 @@ impl batch::Client for Connection {
                                 job,
                                 QueueBindOptions::default(),
                                 FieldTable::new(),
-                            ).map_err(Error::from);
+                            )
+                            .map_err(Error::from);
                         let boxed = Box::new(task) as Box<Future<Item = (), Error = Error> + Send>;
                         tasks.push(boxed);
                     }
                 }
                 future::join_all(tasks).map(move |_| (channel, declared))
-            }).and_then(|(channel, declared)| {
+            })
+            .and_then(|(channel, declared)| {
                 let tasks: Vec<_> = declared
                     .iter()
                     .map(|queue| {
@@ -399,15 +411,18 @@ impl batch::Client for Connection {
                                 "", // We let RabbitMQ generate the consumer tag
                                 BasicConsumeOptions::default(),
                                 FieldTable::new(),
-                            ).map_err(Error::from);
+                            )
+                            .map_err(Error::from);
                         Box::new(task)
                             as Box<
                                 Future<Item = consumer::Consumer<stream::Stream>, Error = Error>
                                     + Send,
                             >
-                    }).collect();
+                    })
+                    .collect();
                 future::join_all(tasks).map(|consumers| (channel, consumers))
-            }).and_then(|(channel, mut consumers)| {
+            })
+            .and_then(|(channel, mut consumers)| {
                 let combined: Box<
                     Stream<Item = message::Delivery, Error = Error> + Send + 'static,
                 > = Box::new(consumers.pop().unwrap().map_err(Error::from));
@@ -418,7 +433,8 @@ impl batch::Client for Connection {
                     };
                     let combined = Box::new(combined.select(stream.map_err(Error::from)));
                     Ok(future::Loop::Continue((combined, consumers)))
-                }).map(move |combined| Consumer::new(channel, combined))
+                })
+                .map(move |combined| Consumer::new(channel, combined))
             });
         Box::new(task)
     }

--- a/batch-rabbitmq/src/declare.rs
+++ b/batch-rabbitmq/src/declare.rs
@@ -1,4 +1,4 @@
-use ConnectionBuilder;
+use crate::ConnectionBuilder;
 
 /// A trait used to declare queues to RabbitMQ.
 pub trait Declare {

--- a/batch-rabbitmq/src/delivery.rs
+++ b/batch-rabbitmq/src/delivery.rs
@@ -194,7 +194,9 @@ impl batch::Delivery for Delivery {
         let delivery_tag = self.delivery_tag;
         log::debug!(
             "ack; id={} job={:?} delivery_tag={:?}",
-            id, job, delivery_tag
+            id,
+            job,
+            delivery_tag
         );
         let task = self
             .channel
@@ -209,7 +211,9 @@ impl batch::Delivery for Delivery {
         let delivery_tag = self.delivery_tag;
         log::debug!(
             "reject; id={} job={:?} delivery_tag={:?}",
-            id, job, delivery_tag
+            id,
+            job,
+            delivery_tag
         );
         let task = self
             .channel

--- a/batch-rabbitmq/src/delivery.rs
+++ b/batch-rabbitmq/src/delivery.rs
@@ -1,5 +1,5 @@
 use batch;
-use failure::Error;
+use failure::{bail, Error};
 use futures::{Future, Poll};
 use lapin::channel;
 use lapin::message;
@@ -10,7 +10,7 @@ use std::fmt;
 use std::time::Duration;
 use uuid::Uuid;
 
-use stream;
+use crate::stream;
 
 /// A delivery is a message received from RabbitMQ.
 ///
@@ -192,7 +192,7 @@ impl batch::Delivery for Delivery {
         let id = self.properties().id;
         let job = &self.properties().task;
         let delivery_tag = self.delivery_tag;
-        debug!(
+        log::debug!(
             "ack; id={} job={:?} delivery_tag={:?}",
             id, job, delivery_tag
         );
@@ -207,7 +207,7 @@ impl batch::Delivery for Delivery {
         let id = self.properties().id;
         let job = &self.properties().task;
         let delivery_tag = self.delivery_tag;
-        debug!(
+        log::debug!(
             "reject; id={} job={:?} delivery_tag={:?}",
             id, job, delivery_tag
         );

--- a/batch-rabbitmq/src/lib.rs
+++ b/batch-rabbitmq/src/lib.rs
@@ -15,10 +15,10 @@ pub mod export;
 mod queue;
 mod stream;
 
-#[cfg(feature = "codegen")]
-pub use batch_rabbitmq_codegen::queues;
 pub use crate::connection::{Builder as ConnectionBuilder, ConnectFuture, Connection, SendFuture};
 pub use crate::declare::Declare;
 pub use crate::delivery::{AcknowledgeFuture, Delivery, RejectFuture};
 pub use crate::exchange::{Builder as ExchangeBuilder, Exchange, Kind as ExchangeKind};
 pub use crate::queue::{Builder as QueueBuilder, Queue};
+#[cfg(feature = "codegen")]
+pub use batch_rabbitmq_codegen::queues;

--- a/batch-rabbitmq/src/lib.rs
+++ b/batch-rabbitmq/src/lib.rs
@@ -4,30 +4,6 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 
-extern crate amq_protocol;
-extern crate batch;
-#[cfg(feature = "codegen")]
-extern crate batch_rabbitmq_codegen;
-extern crate bytes;
-#[macro_use]
-extern crate failure;
-#[macro_use]
-extern crate futures;
-extern crate lapin_async;
-extern crate lapin_futures as lapin;
-#[macro_use]
-extern crate log;
-extern crate native_tls;
-#[macro_use]
-extern crate serde;
-extern crate serde_json;
-extern crate tokio_executor;
-extern crate tokio_io;
-extern crate tokio_reactor;
-extern crate tokio_tcp;
-extern crate tokio_tls;
-extern crate uuid;
-
 mod connection;
 mod consumer;
 mod declare;
@@ -41,8 +17,8 @@ mod stream;
 
 #[cfg(feature = "codegen")]
 pub use batch_rabbitmq_codegen::queues;
-pub use connection::{Builder as ConnectionBuilder, ConnectFuture, Connection, SendFuture};
-pub use declare::Declare;
-pub use delivery::{AcknowledgeFuture, Delivery, RejectFuture};
-pub use exchange::{Builder as ExchangeBuilder, Exchange, Kind as ExchangeKind};
-pub use queue::{Builder as QueueBuilder, Queue};
+pub use crate::connection::{Builder as ConnectionBuilder, ConnectFuture, Connection, SendFuture};
+pub use crate::declare::Declare;
+pub use crate::delivery::{AcknowledgeFuture, Delivery, RejectFuture};
+pub use crate::exchange::{Builder as ExchangeBuilder, Exchange, Kind as ExchangeKind};
+pub use crate::queue::{Builder as QueueBuilder, Queue};

--- a/batch-rabbitmq/src/queue.rs
+++ b/batch-rabbitmq/src/queue.rs
@@ -5,7 +5,7 @@ use serde_json;
 use std::collections::BTreeMap;
 use std::fmt;
 
-use {ConnectionBuilder, Exchange};
+use crate::{ConnectionBuilder, Exchange};
 
 /// A builder for the [`Queue`] type.
 ///

--- a/batch-rabbitmq/src/stream.rs
+++ b/batch-rabbitmq/src/stream.rs
@@ -44,7 +44,8 @@ impl Stream {
                                 .map_err(|e| e.into())
                                 .into_future()
                                 .map(|s| (s, connector))
-                        }).and_then(move |(stream, connector)| {
+                        })
+                        .and_then(move |(stream, connector)| {
                             connector
                                 .connect_async(&host, stream)
                                 .map(Stream::Tls)

--- a/batch-rabbitmq/src/stream.rs
+++ b/batch-rabbitmq/src/stream.rs
@@ -18,13 +18,13 @@ pub enum Stream {
 
 impl Stream {
     pub(crate) fn new(uri: AMQPUri) -> impl Future<Item = Self, Error = Error> {
-        trace!("Establishing TCP connection");
+        log::trace!("Establishing TCP connection");
         net::TcpStream::connect((uri.authority.host.clone().as_ref(), uri.authority.port))
             .map_err(Error::from)
             .into_future()
             .and_then(move |stream| {
                 let task = if uri.scheme == AMQPScheme::AMQP {
-                    trace!("Wrapping TCP connection into tokio-tcp");
+                    log::trace!("Wrapping TCP connection into tokio-tcp");
                     let handle = Handle::current();
                     let task = TcpStream::from_std(stream, &handle)
                         .map(Stream::Raw)
@@ -32,7 +32,7 @@ impl Stream {
                         .into_future();
                     Box::new(task) as Box<Future<Item = Stream, Error = Error> + Send>
                 } else {
-                    trace!("Wrapping TCP connection into tokio-tls");
+                    log::trace!("Wrapping TCP connection into tokio-tls");
                     let host = uri.authority.host.clone();
                     let task = TlsConnector::builder()
                         .map_err(|e| e.into())

--- a/batch-stub/Cargo.toml
+++ b/batch-stub/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "batch-stub"
 description = "Testing utilities for the Batch library"
 repository = "https://github.com/kureuil/batch-rs"

--- a/batch-stub/src/client.rs
+++ b/batch-stub/src/client.rs
@@ -1,11 +1,9 @@
-use batch;
 use failure::Error;
-use futures::{self, future};
+use futures::future;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 mod sealed {
-    use batch;
     use failure::Error;
     use futures::future;
     use serde::{Deserialize, Serialize};

--- a/batch-stub/src/lib.rs
+++ b/batch-stub/src/lib.rs
@@ -8,11 +8,6 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 
-extern crate batch;
-extern crate failure;
-extern crate futures;
-extern crate serde;
-
 mod client;
 
-pub use client::Client;
+pub use crate::client::Client;

--- a/batch-test/Cargo.toml
+++ b/batch-test/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "batch-test"
 description = "Testing utilities for Batch adapters"
 repository = "https://github.com/kureuil/batch-rs"

--- a/examples/rabbitmq-simple/Cargo.toml
+++ b/examples/rabbitmq-simple/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "batch-example-rabbitmq-standalone"
 version = "0.2.0"
 authors = ["Louis Person <louis@person.guru>"]

--- a/examples/rabbitmq-simple/src/bin/client.rs
+++ b/examples/rabbitmq-simple/src/bin/client.rs
@@ -1,12 +1,8 @@
-extern crate batch;
 extern crate batch_example_rabbitmq_standalone as example;
-extern crate batch_rabbitmq;
-extern crate env_logger;
-extern crate tokio;
 
 use tokio::prelude::Future;
 
-use example::{jobs, queues};
+use crate::example::{jobs, queues};
 
 fn main() {
     env_logger::init();

--- a/examples/rabbitmq-simple/src/bin/client.rs
+++ b/examples/rabbitmq-simple/src/bin/client.rs
@@ -13,6 +13,7 @@ fn main() {
             let filepath = "./westworld-2x06.mkv".into();
             let job = jobs::convert_video_file(filepath, jobs::VideoFormat::Mpeg4);
             queues::Transcoding(job).dispatch(&mut client)
-        }).map_err(|e| eprintln!("An error occured: {}", e));
+        })
+        .map_err(|e| eprintln!("An error occured: {}", e));
     tokio::run(task);
 }

--- a/examples/rabbitmq-simple/src/bin/worker.rs
+++ b/examples/rabbitmq-simple/src/bin/worker.rs
@@ -1,13 +1,8 @@
-extern crate batch;
 extern crate batch_example_rabbitmq_standalone as example;
-extern crate batch_rabbitmq;
-extern crate env_logger;
-extern crate failure;
-extern crate tokio;
 
 use tokio::prelude::Future;
 
-use example::queues;
+use crate::example::queues;
 
 fn main() {
     env_logger::init();

--- a/examples/rabbitmq-simple/src/lib.rs
+++ b/examples/rabbitmq-simple/src/lib.rs
@@ -1,7 +1,3 @@
-extern crate batch;
-extern crate batch_rabbitmq;
-extern crate serde;
-
 pub mod queues {
     use batch_rabbitmq::queues;
 

--- a/examples/rabbitmq-warp/Cargo.toml
+++ b/examples/rabbitmq-warp/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "batch-example-rabbitmq-warp"
 version = "0.2.0"
 authors = ["Louis Person <louis@person.guru>"]

--- a/examples/rabbitmq-warp/src/bin/server.rs
+++ b/examples/rabbitmq-warp/src/bin/server.rs
@@ -1,12 +1,8 @@
-extern crate batch;
 extern crate batch_example_rabbitmq_warp as example;
-extern crate batch_rabbitmq;
-extern crate tokio;
-extern crate warp;
 
 use tokio::prelude::Future;
 
-use example::{endpoints, queues};
+use crate::example::{endpoints, queues};
 
 fn main() {
     let task = batch_rabbitmq::Connection::build("amqp://guest:guest@localhost/%2f")

--- a/examples/rabbitmq-warp/src/bin/worker.rs
+++ b/examples/rabbitmq-warp/src/bin/worker.rs
@@ -1,13 +1,8 @@
-extern crate batch;
 extern crate batch_example_rabbitmq_warp as example;
-extern crate batch_rabbitmq;
-extern crate env_logger;
-extern crate failure;
-extern crate tokio;
 
 use tokio::prelude::Future;
 
-use example::queues;
+use crate::example::queues;
 
 fn main() {
     env_logger::init();

--- a/examples/rabbitmq-warp/src/lib.rs
+++ b/examples/rabbitmq-warp/src/lib.rs
@@ -1,14 +1,3 @@
-extern crate batch;
-extern crate batch_rabbitmq;
-extern crate batch_stub;
-#[cfg(test)]
-extern crate env_logger;
-extern crate futures;
-extern crate serde;
-#[cfg(test)]
-extern crate tokio;
-extern crate warp;
-
 pub mod queues {
     use batch_rabbitmq::queues;
 
@@ -53,10 +42,8 @@ pub mod jobs {
 
 pub mod endpoints {
     use super::{jobs, queues};
-    use batch;
-    use batch_rabbitmq;
     use futures::Future;
-    use warp::{self, Filter, Rejection, Reply};
+    use warp::{Filter, Rejection, Reply};
 
     fn transcode(
         mut client: impl batch::Client,
@@ -81,8 +68,6 @@ pub mod endpoints {
     #[cfg(test)]
     mod test {
         use super::*;
-        use batch_stub;
-        use env_logger;
         use tokio::runtime::current_thread::Runtime;
 
         #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 use failure::Error;
 use futures::{Future, Stream};
 
-use {Delivery, Dispatch};
+use crate::{Delivery, Dispatch};
 
 /// A message broker client.
 ///

--- a/src/delivery.rs
+++ b/src/delivery.rs
@@ -1,7 +1,7 @@
 use failure::Error;
 use futures::Future;
 
-use job::Properties;
+use crate::job::Properties;
 
 /// A message that can be received from a broker.
 pub trait Delivery: Send {

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,7 +1,7 @@
 use failure::Error;
 use serde_json::to_vec;
 
-use {Job, Properties};
+use crate::{Job, Properties};
 
 /// A message that will be sent to a broker.
 ///

--- a/src/job.rs
+++ b/src/job.rs
@@ -8,7 +8,7 @@ use futures::Future;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use Factory;
+use crate::Factory;
 
 /// A job and its related metadata (name, queue, timeout, etc.)
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,6 @@ mod query;
 mod queue;
 mod worker;
 
-#[cfg(feature = "codegen")]
-pub use batch_codegen::job;
 pub use crate::client::{Client, Consumer};
 pub use crate::delivery::Delivery;
 pub use crate::dispatch::Dispatch;
@@ -82,3 +80,5 @@ pub use crate::job::{Job, Properties};
 pub use crate::query::{DispatchFuture, Query};
 pub use crate::queue::Queue;
 pub use crate::worker::{Work, Worker};
+#[cfg(feature = "codegen")]
+pub use batch_codegen::job;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,18 +60,6 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 
-#[cfg(feature = "codegen")]
-extern crate batch_codegen;
-extern crate failure;
-#[macro_use]
-extern crate futures;
-extern crate log;
-extern crate serde;
-extern crate serde_json;
-extern crate tokio_executor;
-extern crate uuid;
-extern crate wait_timeout;
-
 mod client;
 mod delivery;
 mod dispatch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,11 +86,11 @@ mod worker;
 
 #[cfg(feature = "codegen")]
 pub use batch_codegen::job;
-pub use client::{Client, Consumer};
-pub use delivery::Delivery;
-pub use dispatch::Dispatch;
-pub use factory::Factory;
-pub use job::{Job, Properties};
-pub use query::{DispatchFuture, Query};
-pub use queue::Queue;
-pub use worker::{Work, Worker};
+pub use crate::client::{Client, Consumer};
+pub use crate::delivery::Delivery;
+pub use crate::dispatch::Dispatch;
+pub use crate::factory::Factory;
+pub use crate::job::{Job, Properties};
+pub use crate::query::{DispatchFuture, Query};
+pub use crate::queue::Queue;
+pub use crate::worker::{Work, Worker};

--- a/src/query.rs
+++ b/src/query.rs
@@ -180,7 +180,7 @@ where
                 self.poll()
             }
             DispatchState::Polling(ref mut f) => {
-                let _ = try_ready!(f.poll());
+                let _ = futures::try_ready!(f.poll());
                 Ok(Async::Ready(()))
             }
         }

--- a/src/query.rs
+++ b/src/query.rs
@@ -3,9 +3,9 @@ use futures::{Async, Future, Poll};
 use log::debug;
 use std::marker::PhantomData;
 
-use dispatch::Dispatch;
+use crate::dispatch::Dispatch;
 
-use {Client, Job, Properties, Queue};
+use crate::{Client, Job, Properties, Queue};
 
 /// A fluent interface to configure jobs before dispatching them.
 ///

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -3,7 +3,7 @@
 use failure::Error;
 use futures::Future;
 
-use Factory;
+use crate::Factory;
 
 /// A resource that has to be declared to be used.
 ///

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -16,10 +16,10 @@ use wait_timeout::ChildExt;
 use crate::{Client, Delivery, Factory, Query, Queue};
 
 mod sealed {
+    use crate::{Factory, Job};
     use failure::Error;
     use futures::future;
     use serde::{Deserialize, Serialize};
-    use crate::{Factory, Job};
 
     /// Stub job used to trick the type system in `Connection::declare`.
     #[derive(Debug, Deserialize, Serialize)]
@@ -53,8 +53,10 @@ pub struct Worker<C> {
     client: C,
     queues: HashSet<String>,
     factory: Factory,
-    callbacks:
-        HashMap<String, fn(&[u8], &crate::Factory) -> Box<dyn Future<Item = (), Error = Error> + Send>>,
+    callbacks: HashMap<
+        String,
+        fn(&[u8], &crate::Factory) -> Box<dyn Future<Item = (), Error = Error> + Send>,
+    >,
 }
 
 impl<C> fmt::Debug for Worker<C>

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -13,13 +13,13 @@ use std::sync::mpsc;
 use tokio_executor;
 use wait_timeout::ChildExt;
 
-use {Client, Delivery, Factory, Query, Queue};
+use crate::{Client, Delivery, Factory, Query, Queue};
 
 mod sealed {
     use failure::Error;
     use futures::future;
     use serde::{Deserialize, Serialize};
-    use {Factory, Job};
+    use crate::{Factory, Job};
 
     /// Stub job used to trick the type system in `Connection::declare`.
     #[derive(Debug, Deserialize, Serialize)]
@@ -54,7 +54,7 @@ pub struct Worker<C> {
     queues: HashSet<String>,
     factory: Factory,
     callbacks:
-        HashMap<String, fn(&[u8], &::Factory) -> Box<dyn Future<Item = (), Error = Error> + Send>>,
+        HashMap<String, fn(&[u8], &crate::Factory) -> Box<dyn Future<Item = (), Error = Error> + Send>>,
 }
 
 impl<C> fmt::Debug for Worker<C>


### PR DESCRIPTION
Mostly automated changes, bumps minimum Rust version to 1.31.